### PR TITLE
ADD: update with MVP trades for API call;

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,12 +1,12 @@
 export const Card = ({ title, subtitle }) => (
   <div className="flex flex-col border-gray-700 border-opacity-10 border-4 shadow-2xl rounded-md ring-opacity-80 ring-offset-white p-2 lg:p-3 xl:p-6 text-center">
-    <div className="bg-white rounded-md p-2 lg:p-3 xl:p-6">
-      <dd className="order-1 text-4xl font-extrabold text-indigo-600">
-        {title}
-      </dd>
-      <dt className="order-2 mt-2 text-sm leading-6 font-small text-gray-500">
+    <div className="bg-white rounded-md p-2 lg:p-3 xl:p-2">
+      <dt className="order-1 py-2 text-sm  font-small text-gray-500">
         {subtitle}
       </dt>
+      <dd className="order-2 pb-4 text-2xl xl:text-3xl font-extrabold text-indigo-600">
+        {title}
+      </dd>
     </div>
   </div>
 )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,11 +4,14 @@ import { Card } from "@components/Card"
 import { Table } from "@components/Table"
 import { HowItWorksStep, Steps } from "@components/HowItWorks"
 
-const Data = [
-  { title: "2M", subtitle: "Total Coins Escrowed" },
-  { title: "$0.038", subtitle: "Last 20 Trades" },
-  { title: "$80,000", subtitle: "Transactions Escrowed" },
-]
+const MockData = {
+  amountEscrowed: 80000,
+  totalNumberOfCoins: 2000000,
+  totalNumberOfTransactions: 1000,
+  weightedAverage: 0.038,
+  lastRate: 0.038,
+  updatedAt: new Date().toISOString(),
+}
 
 const trades = [
   {
@@ -30,7 +33,18 @@ const trades = [
   // More trades...
 ]
 
-export default function Home() {
+//
+
+export default function Home({
+  statistics: {
+    amountEscrowed,
+    totalNumberOfCoins,
+    totalNumberOfTransactions,
+    weightedAverage,
+    lastRate,
+    updatedAt,
+  },
+}) {
   return (
     <>
       <Layout>
@@ -64,7 +78,7 @@ export default function Home() {
         </div>
         {/* Coins / Weighted Average Rate / Total Trades */}
         <div className="bg-gray-100 pt-12 sm:pt-16">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-8">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="max-w-4xl mx-auto text-center">
               <h2 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
                 Trusted by people from over 80 countries.
@@ -79,14 +93,37 @@ export default function Home() {
               </h2>
             </div>
           </div>
-          <div className="mt-10 pb-4 sm:pb-8">
+          <div className="py-4 md:py-8">
             <div className="relative -m-y-12">
               <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="max-w-sm md:max-w-2xl lg:max-w-4xl xl:max-w-6xl mx-auto">
-                  <dl className="rounded-lg space-y-10 md:space-y-0 md:grid md:grid-cols-3 md:space-x-2 lg:space-x-5 xl:space-x-20">
-                    {Data.map((data, index) => {
-                      return <Card {...data} key={`card-${index}`} />
-                    })}
+                  <dl className="rounded-lg space-y-10 md:space-y-0 md:grid md:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-10">
+                    <Card
+                      title={`$${amountEscrowed.toLocaleString()}`}
+                      subtitle="Transaction Amount"
+                    />
+                    <Card
+                      title={totalNumberOfCoins.toLocaleString()}
+                      subtitle="Total number of coins"
+                    />
+                    <Card
+                      title={totalNumberOfTransactions.toLocaleString()}
+                      subtitle="Number of Transactions"
+                    />
+                    <Card
+                      title={`$${weightedAverage / 10000}`}
+                      subtitle="Weighted Average"
+                    />
+                    <Card title={`$${lastRate / 10000}`} subtitle="Last Rate" />
+                    <Card
+                      title={new Date(updatedAt).toLocaleString("en", {
+                        year: "2-digit",
+                        month: "2-digit",
+                        day: "2-digit",
+                        hour: "numeric",
+                      })}
+                      subtitle="Last Trade"
+                    />
                   </dl>
                 </div>
               </div>
@@ -138,4 +175,31 @@ export default function Home() {
       </Layout>
     </>
   )
+}
+
+const transformData = (data) => {
+  return {
+    amountEscrowed: data?.total_transactions ?? MockData.amountEscrowed,
+    totalNumberOfCoins: data?.total_coins ?? MockData.totalNumberOfCoins,
+    totalNumberOfTransactions:
+      data?.total_escrows ?? MockData.totalNumberOfTransactions,
+    weightedAverage: data?.weighted_rate ?? MockData.weightedAverage,
+    lastRate: data?.last_rate ?? MockData.lastRate,
+    updatedAt: data?.updated_at ?? MockData.updatedAt,
+  }
+}
+
+export async function getServerSideProps() {
+  const res = await fetch(
+    `https://tnbcrow.pythonanywhere.com/statistics?format=json`
+  )
+  let response = await res.json()
+
+  let data = transformData(response[0])
+
+  return {
+    props: {
+      statistics: { ...data },
+    }, // will be passed to the page component as props
+  }
 }


### PR DESCRIPTION
reference `Statistics: Total Coins Traded, Total Escrows Completed, Weighted Average Price`  in #16 
- uses MVP - 

Description:
- Adds getServerSideProps to fetch against MVP or use MockData if MVP service is down.

Preview:
<img width="1018" alt="Screenshot 2021-05-08 at 10 17 24 AM" src="https://user-images.githubusercontent.com/3061779/117522989-eab5f980-afe8-11eb-8b77-d8ac5752022c.png">

Todo: 
- add feature flag to call MVP and split request against BE dev and MVP server.

